### PR TITLE
Rename 2026 redesign post title

### DIFF
--- a/src/content/posts/2026-redesign.mdx
+++ b/src/content/posts/2026-redesign.mdx
@@ -1,5 +1,5 @@
 ---
-title: 2026 Redesign
+title: This thing finally looks nice, clean, and calm
 excerpt: Typography-first refresh — IBM Plex, a Flexoki/Everforest palette, and a quieter layout.
 created: 2026-04-17
 modified: 2026-04-17


### PR DESCRIPTION
Renames the 2026 redesign post title from "2026 Redesign" to "This thing finally looks nice, clean, and calm".