### PR TITLE
Collapse .html and clean URLs into one canonical form

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,7 +56,21 @@ const rehypePlugins = [
 
 export default defineConfig({
   site: baseURL,
-  integrations: [copyImagesIntegration(), mdx(), sitemap(), ogImagesIntegration()],
+  integrations: [
+    copyImagesIntegration(),
+    mdx(),
+    // Emit clean URLs in the sitemap (strip .html) so they match the canonical
+    // tags and nginx's 301 redirects — avoids Google flagging pages as
+    // "Alternate page with proper canonical tag".
+    sitemap({
+      serialize(item) {
+        // `/foo/index.html` → `/foo/`, `/foo.html` → `/foo`
+        item.url = item.url.replace(/\/index\.html(\?|$)/, "/$1").replace(/\.html(\?|$)/, "$1");
+        return item;
+      },
+    }),
+    ogImagesIntegration(),
+  ],
   markdown: {
     remarkPlugins,
     rehypePlugins,

--- a/nginx.conf
+++ b/nginx.conf
@@ -46,17 +46,35 @@ server {
         access_log off;
     }
 
-    # Cache HTML files for shorter period
-    location ~* \.html$ {
-        expires 1h;
-        add_header Cache-Control "public, must-revalidate";
-    }
-
     # Serve /sitemap.xml from the Astro-generated sitemap-index.xml
     # (the @astrojs/sitemap integration emits sitemap-index.xml + sitemap-0.xml,
     # but Google Search Console expects /sitemap.xml).
     location = /sitemap.xml {
         try_files /sitemap-index.xml =404;
+    }
+
+    # Canonicalize URLs: 301-redirect *.html to the clean path so we don't have
+    # duplicate URLs for the same page (Google was marking the .html variants
+    # as "Alternate page with proper canonical tag").
+    location = /index.html {
+        return 301 /;
+    }
+    # /404.html is served internally by error_page only; block external access
+    # so it isn't redirected into a loop.
+    location = /404.html {
+        internal;
+    }
+    # NOTE: this regex must come before any other `\.html$` regex location,
+    # since nginx picks the first matching regex.
+    location ~ ^(/.+)\.html$ {
+        return 301 $1$is_args$args;
+    }
+
+    # Cache HTML files for shorter period (applies when try_files serves
+    # $uri.html for a clean URL request).
+    location ~* \.html$ {
+        expires 1h;
+        add_header Cache-Control "public, must-revalidate";
     }
 
     # Handle all routes - try files first, then .html for clean URLs.


### PR DESCRIPTION
## Summary

Google Search Console was flagging several posts and the about page as **"Alternate page with proper canonical tag"** (e.g. `/posts/zed-lambda-deepseek-setup.html`, `/about.html`). Root cause: each page was reachable at two URLs with identical content — `/foo.html` (what `@astrojs/sitemap` advertised, since `build.format: "file"`) and `/foo` (what the canonical tag and internal links pointed to). Google correctly kept one and de-indexed the other.

This collapses everything to the clean (non-`.html`) form:

- **nginx**: 301-redirect `*.html` → clean path (preserving query string), `/index.html` → `/`. `/404.html` is marked `internal` so the `error_page 404` redirect doesn't get caught by the `.html` redirect and loop. Reordered the `\.html$` cache-header regex location below the redirect regex (nginx picks the first matching regex).
- **@astrojs/sitemap**: added a `serialize` hook that strips `.html` (and `/index.html`) from sitemap URLs so sitemap, canonical tag, and 301 target all agree.

Existing `.html` URLs in the wild (old NextJS links, Google's index) now 301 to the clean version — Google should merge the entries on the next crawl.

## Test plan

- [ ] `pnpm run build` succeeds and `dist/sitemap-0.xml` contains clean URLs (no `.html`)
- [ ] Build Docker image, hit `/about.html` → 301 to `/about`
- [ ] Hit `/posts/meet-your-new-team.html` → 301 to `/posts/meet-your-new-team`
- [ ] Hit `/index.html` → 301 to `/`
- [ ] Hit `/does-not-exist` → 404 status, `/404.html` content
- [ ] Hit `/404.html` directly → 404 (internal-only)
- [ ] Hit `/sitemap.xml` → serves sitemap index
- [ ] Canonical tags on post pages still point to non-`.html` path (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)