### PR TITLE
feat: label deploy PRs with auto-merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -99,6 +99,7 @@ jobs:
           token: ${{ secrets.HOMELAB_PAT }}
           path: homelab
           branch: deploy/respawn-io
+          labels: auto-merge
           title: "Deploy respawn-io ${{ steps.sha.outputs.short }}"
           body: |
             Automated deployment PR for respawn-io.


### PR DESCRIPTION
## Summary

- Adds `labels: auto-merge` to the `create-pull-request` step in the deploy job
- Enables the homelab auto-merge workflow ([natikgadzhi/homelab#36](https://github.com/natikgadzhi/homelab/pull/36)) to merge deployment PRs automatically

## How it works

When `peter-evans/create-pull-request` opens or updates a PR with the `auto-merge` label, GitHub fires a `labeled` event. The homelab workflow catches that event, verifies the branch starts with `deploy/`, and merges the PR.

## Test plan
- [ ] Merge homelab PR [#36](https://github.com/natikgadzhi/homelab/pull/36) first
- [ ] Push a commit to main here — verify the deploy PR in homelab is created and auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)