### PR TITLE
Improve sitemap discovery and lastmod metadata

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,11 @@ import sitemap from "@astrojs/sitemap";
 // Remark plugins
 import remarkFigureCaption from "@microflash/remark-figure-caption";
 import { defineConfig } from "astro/config";
+import fs from "node:fs";
+import path from "node:path";
 import rehypeMermaid from "rehype-mermaid";
 import callouts from "remark-callouts";
+import matter from "gray-matter";
 import remarkGfm from "remark-gfm";
 import wikilinks from "remark-wiki-link";
 import { config } from "./blog.config.ts";
@@ -54,9 +57,91 @@ const rehypePlugins = [
   ],
 ];
 
+function normalizeURL(url) {
+  const pathname = url.pathname.replace(/\/$/, "");
+  return `${url.origin}${pathname}` || url.origin;
+}
+
+function collectMarkdownFiles(directory) {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return collectMarkdownFiles(fullPath);
+    }
+
+    if (!/\.(md|mdx)$/.test(entry.name) || entry.name.endsWith(".excalidraw.md")) {
+      return [];
+    }
+
+    return [fullPath];
+  });
+}
+
+function buildSitemapLastmodMap() {
+  const lastmodMap = new Map();
+
+  const contentSources = [
+    {
+      directory: path.join(process.cwd(), "src/content/posts"),
+      routeBase: "/posts/",
+    },
+    {
+      directory: path.join(process.cwd(), "src/content/daily"),
+      routeBase: "/daily/",
+    },
+  ];
+
+  for (const source of contentSources) {
+    for (const filePath of collectMarkdownFiles(source.directory)) {
+      const fileContents = fs.readFileSync(filePath, "utf8");
+      const { data } = matter(fileContents);
+
+      if (data.draft) {
+        continue;
+      }
+
+      const relativePath = path.relative(source.directory, filePath).replace(/\.(md|mdx)$/, "");
+      let modified = data.modified ?? data.created;
+
+      if (!modified && source.routeBase === "/daily/" && /^\d{4}-\d{2}-\d{2}$/.test(relativePath)) {
+        modified = `${relativePath}T00:00:00.000Z`;
+      }
+
+      if (!modified) {
+        continue;
+      }
+
+      const url = new URL(`${source.routeBase}${relativePath}`, baseURL);
+      lastmodMap.set(normalizeURL(url), new Date(modified));
+    }
+  }
+
+  return lastmodMap;
+}
+
+const sitemapLastmodMap = buildSitemapLastmodMap();
+
 export default defineConfig({
   site: baseURL,
-  integrations: [copyImagesIntegration(), mdx(), sitemap(), ogImagesIntegration()],
+  integrations: [
+    copyImagesIntegration(),
+    mdx(),
+    sitemap({
+      serialize(item) {
+        const lastmod = sitemapLastmodMap.get(normalizeURL(new URL(item.url)));
+
+        if (lastmod) {
+          item.lastmod = lastmod;
+        }
+
+        return item;
+      },
+    }),
+    ogImagesIntegration(),
+  ],
   markdown: {
     remarkPlugins,
     rehypePlugins,

--- a/nginx.conf
+++ b/nginx.conf
@@ -52,16 +52,8 @@ server {
         add_header Cache-Control "public, must-revalidate";
     }
 
-    # Serve /sitemap.xml from the Astro-generated sitemap-index.xml
-    # (the @astrojs/sitemap integration emits sitemap-index.xml + sitemap-0.xml,
-    # but Google Search Console expects /sitemap.xml).
-    location = /sitemap.xml {
-        try_files /sitemap-index.xml =404;
-    }
-
     # Handle all routes - try files first, then .html for clean URLs.
-    # Do NOT fall back to /index.html — missing URLs must return 404,
-    # otherwise non-HTML paths like /sitemap.xml serve the homepage.
+    # Do NOT fall back to /index.html — missing URLs must return 404.
     location / {
         try_files $uri $uri/index.html $uri.html =404;
     }

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from "astro";
+import { config } from "../../blog.config";
+
+const robots = `User-agent: *
+Allow: /
+
+Sitemap: ${new URL("/sitemap-index.xml", config.baseURL).toString()}
+`;
+
+export const GET: APIRoute = () =>
+  new Response(robots, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });


### PR DESCRIPTION
Summary
- point sitemap discovery at sitemap-index.xml via a generated robots.txt route
- remove the nginx sitemap.xml alias workaround
- add lastmod values to Astro sitemap entries using post metadata and daily slug fallbacks

Verification
- ran pnpm build
- confirmed dist/robots.txt, dist/sitemap-index.xml, and dist/sitemap-0.xml are generated
- confirmed dist/sitemap-0.xml includes lastmod for posts and daily notes