### PR TITLE
fix: remove Plausible, restore Counterscale, add font CORS headers

### DIFF
--- a/blog.config.ts
+++ b/blog.config.ts
@@ -29,14 +29,4 @@ export const config = {
   footer: {
     copyright: "© Natik Gadzhi",
   },
-
-  counterscale: {
-    siteId: "respawn-io",
-    url: "https://patient-butterfly-cfd2.nate-bf6.workers.dev",
-  },
-
-  plausible: {
-    scriptId: "pa-wSp7pBzCYOQ0W7O-WgH1K",
-    url: "https://analytics.respawn.io",
-  },
 };

--- a/blog.config.ts
+++ b/blog.config.ts
@@ -29,4 +29,9 @@ export const config = {
   footer: {
     copyright: "© Natik Gadzhi",
   },
+
+  counterscale: {
+    siteId: "respawn-io",
+    url: "https://patient-butterfly-cfd2.nate-bf6.workers.dev",
+  },
 };

--- a/public/_headers
+++ b/public/_headers
@@ -22,7 +22,9 @@
   Cache-Control: public, max-age=31536000, immutable
 /*.woff
   Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
 /*.woff2
   Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
 /*.webp
   Cache-Control: public, max-age=31536000, immutable

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -72,6 +72,14 @@ const canonicalURL = new URL(pathnameWithoutHtml, Astro.site);
     <!-- Fediverse verification -->
     <link rel="me" href={config.author.fediverseURL} />
 
+    <!-- Counterscale Analytics -->
+    <script
+      is:inline
+      id="counterscale-script"
+      data-site-id={config.counterscale.siteId}
+      src={`${config.counterscale.url}/tracker.js`}
+      defer
+    />
   </head>
   <body class="bg-paper text-ink font-serif selection:bg-surface">
     <main class="min-h-screen max-w-3xl mx-auto px-6 md:px-8">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -72,30 +72,6 @@ const canonicalURL = new URL(pathnameWithoutHtml, Astro.site);
     <!-- Fediverse verification -->
     <link rel="me" href={config.author.fediverseURL} />
 
-    <!-- Counterscale Analytics -->
-    <script
-      is:inline
-      id="counterscale-script"
-      data-site-id={config.counterscale.siteId}
-      src={`${config.counterscale.url}/tracker.js`}
-      defer
-    />
-
-    <!-- Privacy-friendly analytics by Plausible -->
-    <script is:inline async src={`${config.plausible.url}/js/${config.plausible.scriptId}.js`}></script>
-    <script is:inline>
-      ((window.plausible =
-        window.plausible ||
-        function () {
-          (plausible.q = plausible.q || []).push(arguments);
-        }),
-        (plausible.init =
-          plausible.init ||
-          function (i) {
-            plausible.o = i || {};
-          }));
-      plausible.init();
-    </script>
   </head>
   <body class="bg-paper text-ink font-serif selection:bg-surface">
     <main class="min-h-screen max-w-3xl mx-auto px-6 md:px-8">


### PR DESCRIPTION
## Summary

- **Remove Plausible analytics** — `analytics.respawn.io` returns HTTP 403, causing `OpaqueResponseBlocking` + script load failure on every page (flagged by Ahrefs as JS errors)
- **Restore Counterscale analytics** — kept as-is with `data-site-id` attribute on the script tag
- **Add `Access-Control-Allow-Origin: *` for woff/woff2 fonts** in `_headers` — Vite emits `<link rel="preload" as="font" crossorigin>` tags; the `crossorigin` attribute puts the request in CORS mode, so without this header Cloudflare Pages returns fonts without `Access-Control-Allow-Origin` and the browser blocks them (seen as font load failures on `natik.wtf`)

## Test plan

- [ ] Merge and confirm Cloudflare Pages build passes
- [ ] Open the site in browser devtools — no script load errors, no font load errors
- [ ] Check Counterscale dashboard shows pageviews after deploy
- [ ] Note: Cloudflare Web Analytics beacon (auto-injected by CF Pages) still has a stale SRI hash — disable it in the Cloudflare Pages dashboard under Settings → Web Analytics to clear that remaining error

https://claude.ai/code/session_01DpgqmufnZeaxSMUwcwjq4F