### PR TITLE
Add visual + markup regression check for PR previews

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      preview-url: ${{ steps.deploy.outputs.deployment-url }}
 
     steps:
       - name: Checkout repository
@@ -60,6 +62,68 @@ jobs:
             const alias = "${{ steps.deploy.outputs.pages-deployment-alias-url }}";
             const marker = "<!-- cloudflare-pages-preview -->";
             const body = `${marker}\n**Cloudflare Pages preview:** ${alias || url}\n\nLatest deployment: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            }
+
+  # Informational visual + markup regression check: screenshots the preview
+  # deployment against production and posts a per-page diff summary on the PR.
+  # Never fails the build — content-driven differences are expected.
+  visual-diff:
+    name: Visual diff vs production
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    if: github.event_name == 'pull_request' && needs.build-and-deploy.outputs.preview-url != ''
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Compare preview against production
+        run: node --experimental-strip-types scripts/visual-diff.ts
+        env:
+          PREVIEW_URL: ${{ needs.build-and-deploy.outputs.preview-url }}
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-diff-report
+          path: visual-diff-report/
+
+      - name: Comment diff summary on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- visual-diff-report -->";
+            const summary = fs.readFileSync("visual-diff-report/summary.md", "utf-8");
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\n## Visual diff vs production\n\n${summary}\n\n[Full report artifact](${runUrl})`;
             const { data: comments } = await github.rest.issues.listComments({
               ...context.repo,
               issue_number: context.issue.number,

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ yarn-error.log*
 
 # vercel
 .vercel
+visual-diff-report/

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "@types/hast": "^3.0.5",
     "@types/mdast": "^4.0.4",
     "@types/node": "^26.1.1",
+    "@types/pngjs": "^6.0.5",
     "@types/unist": "^3.0.3",
+    "pixelmatch": "^7.2.0",
+    "pngjs": "^7.0.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,18 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
+      pixelmatch:
+        specifier: ^7.2.0
+        version: 7.2.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1295,6 +1304,9 @@ packages:
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -2618,6 +2630,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
@@ -2627,6 +2643,10 @@ packages:
     resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -4323,6 +4343,10 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 26.1.1
 
   '@types/sax@1.2.7':
     dependencies:
@@ -6162,6 +6186,10 @@ snapshots:
 
   picomatch@4.0.5: {}
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.61.1: {}
 
   playwright@1.61.1:
@@ -6169,6 +6197,8 @@ snapshots:
       playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   points-on-curve@0.2.0: {}
 

--- a/scripts/visual-diff.ts
+++ b/scripts/visual-diff.ts
@@ -1,0 +1,195 @@
+/**
+ * Visual + markup regression check: compares a set of pages on a preview
+ * deployment against the production site.
+ *
+ * Usage: PREVIEW_URL=https://<hash>.respawn-io.pages.dev node --experimental-strip-types scripts/visual-diff.ts
+ *
+ * Screenshots both versions of each page, diffs them with pixelmatch, and
+ * compares normalized HTML markup. Writes a markdown summary and per-page
+ * artifacts (screenshots + visual diff) to OUT_DIR (default: visual-diff-report).
+ *
+ * Informational by design: always exits 0. Content-driven differences (a new
+ * post on the preview shows up on index pages) are expected — a human reads
+ * the report on the PR.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import pixelmatch from "pixelmatch";
+import { chromium, type Page } from "playwright";
+import { PNG } from "pngjs";
+
+const PREVIEW_URL = process.env.PREVIEW_URL?.replace(/\/$/, "");
+const PROD_URL = (process.env.PROD_URL ?? "https://respawn.io").replace(/\/$/, "");
+const OUT_DIR = process.env.OUT_DIR ?? "visual-diff-report";
+
+// Representative pages: each layout, plus posts exercising the trickier
+// pipeline features (mermaid, excalidraw, images, callouts, code blocks).
+const PAGES = [
+  "/",
+  "/about",
+  "/daily",
+  "/posts/contentlayer-mermaid-diagrams",
+  "/posts/contentlayer-with-excalidraw",
+  "/posts/the-natik-user-guide",
+  "/posts/app-icons-in-swiftui",
+  "/tags/astro",
+];
+
+const VIEWPORT = { width: 1280, height: 720 };
+// Pixel color distance threshold for pixelmatch (0-1); 0.1 is the usual default.
+const PIXEL_THRESHOLD = 0.1;
+// Pages whose visual diff exceeds this fraction of pixels get flagged and a diff image.
+const FLAG_RATIO = 0.0002;
+
+interface PageResult {
+  path: string;
+  pixelDiffRatio: number;
+  markupChangedLines: number;
+  markupTotalLines: number;
+  error?: string;
+}
+
+function slugify(pagePath: string): string {
+  return pagePath === "/" ? "home" : pagePath.replace(/^\//, "").replace(/\//g, "-");
+}
+
+/** Normalize built HTML so hashed asset names and version strings don't count as changes. */
+function normalizeMarkup(html: string): string[] {
+  return html
+    .replace(/\/_astro\/[\w.-]+\.(js|css|webp|png|jpg|svg|woff2)/g, "/_astro/ASSET")
+    .replace(/<meta name="generator"[^>]*>/g, "")
+    .replace(/astro-[a-z0-9]{8}/g, "astro-SCOPE")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Count lines whose occurrence differs between the two documents. */
+function countChangedLines(a: string[], b: string[]): number {
+  const counts = new Map<string, number>();
+  for (const line of a) counts.set(line, (counts.get(line) ?? 0) + 1);
+  for (const line of b) counts.set(line, (counts.get(line) ?? 0) - 1);
+  let changed = 0;
+  for (const count of counts.values()) changed += Math.abs(count);
+  return changed;
+}
+
+async function screenshot(page: Page, url: string): Promise<Buffer> {
+  await page.goto(url, { waitUntil: "networkidle", timeout: 60_000 });
+  // Let fonts and any late layout settle.
+  await page.waitForTimeout(500);
+  return page.screenshot({ fullPage: true, animations: "disabled" });
+}
+
+/** Pad both images to the same dimensions so pixelmatch can compare them. */
+function padToMatch(a: PNG, b: PNG): { a: PNG; b: PNG } {
+  const width = Math.max(a.width, b.width);
+  const height = Math.max(a.height, b.height);
+  const pad = (src: PNG): PNG => {
+    if (src.width === width && src.height === height) return src;
+    const out = new PNG({ width, height, fill: true });
+    out.data.fill(255);
+    PNG.bitblt(src, out, 0, 0, src.width, src.height, 0, 0);
+    return out;
+  };
+  return { a: pad(a), b: pad(b) };
+}
+
+async function comparePage(page: Page, pagePath: string): Promise<PageResult> {
+  const slug = slugify(pagePath);
+
+  const prodShot = await screenshot(page, `${PROD_URL}${pagePath}`);
+  const previewShot = await screenshot(page, `${PREVIEW_URL}${pagePath}`);
+
+  const { a: prodPng, b: previewPng } = padToMatch(PNG.sync.read(prodShot), PNG.sync.read(previewShot));
+  const { width, height } = prodPng;
+  const diffPng = new PNG({ width, height });
+  const diffPixels = pixelmatch(prodPng.data, previewPng.data, diffPng.data, width, height, {
+    threshold: PIXEL_THRESHOLD,
+  });
+  const pixelDiffRatio = diffPixels / (width * height);
+
+  const [prodHtml, previewHtml] = await Promise.all(
+    [`${PROD_URL}${pagePath}`, `${PREVIEW_URL}${pagePath}`].map(async (url) => {
+      const res = await fetch(url);
+      return res.text();
+    }),
+  );
+  const prodLines = normalizeMarkup(prodHtml);
+  const previewLines = normalizeMarkup(previewHtml);
+  const markupChangedLines = countChangedLines(prodLines, previewLines);
+
+  if (pixelDiffRatio > FLAG_RATIO) {
+    fs.writeFileSync(path.join(OUT_DIR, `${slug}.prod.png`), PNG.sync.write(prodPng));
+    fs.writeFileSync(path.join(OUT_DIR, `${slug}.preview.png`), PNG.sync.write(previewPng));
+    fs.writeFileSync(path.join(OUT_DIR, `${slug}.diff.png`), PNG.sync.write(diffPng));
+  }
+
+  return {
+    path: pagePath,
+    pixelDiffRatio,
+    markupChangedLines,
+    markupTotalLines: Math.max(prodLines.length, previewLines.length),
+  };
+}
+
+async function main(): Promise<void> {
+  if (!PREVIEW_URL) {
+    console.error("PREVIEW_URL environment variable is required");
+    process.exit(1);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  // CHROMIUM_PATH lets local environments point at a system Chromium instead
+  // of the Playwright-managed download.
+  const browser = await chromium.launch({ executablePath: process.env.CHROMIUM_PATH });
+  const page = await browser.newPage({ viewport: VIEWPORT, reducedMotion: "reduce" });
+
+  const results: PageResult[] = [];
+  for (const pagePath of PAGES) {
+    try {
+      results.push(await comparePage(page, pagePath));
+      console.log(`compared ${pagePath}`);
+    } catch (e) {
+      results.push({
+        path: pagePath,
+        pixelDiffRatio: Number.NaN,
+        markupChangedLines: 0,
+        markupTotalLines: 0,
+        error: (e as Error).message.slice(0, 200),
+      });
+      console.error(`failed ${pagePath}: ${(e as Error).message.slice(0, 200)}`);
+    }
+  }
+
+  await browser.close();
+
+  const lines = [
+    `Comparing preview (${PREVIEW_URL}) against production (${PROD_URL}).`,
+    "",
+    "| Page | Pixel diff | Markup lines changed | |",
+    "|---|---|---|---|",
+  ];
+  for (const r of results) {
+    if (r.error) {
+      lines.push(`| \`${r.path}\` | — | — | ⚠️ ${r.error} |`);
+      continue;
+    }
+    const pct = (r.pixelDiffRatio * 100).toFixed(2);
+    const flag = r.pixelDiffRatio > FLAG_RATIO || r.markupChangedLines > 0 ? "👀" : "✅";
+    lines.push(`| \`${r.path}\` | ${pct}% | ${r.markupChangedLines} of ~${r.markupTotalLines} | ${flag} |`);
+  }
+  lines.push(
+    "",
+    "Pages flagged 👀 have screenshots and a visual diff in the workflow artifact.",
+    "Content differences (e.g. a new post appearing on index pages) are expected to flag — use judgment.",
+  );
+
+  const summary = lines.join("\n");
+  fs.writeFileSync(path.join(OUT_DIR, "summary.md"), summary);
+  console.log(`\n${summary}`);
+}
+
+await main();

--- a/scripts/visual-diff.ts
+++ b/scripts/visual-diff.ts
@@ -36,6 +36,9 @@ const PAGES = [
   "/tags/astro",
 ];
 
+// Feeds get a markup-only comparison (no screenshots).
+const FEEDS = ["/rss/feed.xml"];
+
 const VIEWPORT = { width: 1280, height: 720 };
 // Pixel color distance threshold for pixelmatch (0-1); 0.1 is the usual default.
 const PIXEL_THRESHOLD = 0.1;
@@ -73,6 +76,38 @@ function countChangedLines(a: string[], b: string[]): number {
   let changed = 0;
   for (const count of counts.values()) changed += Math.abs(count);
   return changed;
+}
+
+/**
+ * Normalize a feed document: break the single-line XML into element-ish lines
+ * and strip values that legitimately change every build.
+ */
+function normalizeFeed(xml: string): string[] {
+  return xml
+    .replace(/<lastBuildDate>[^<]*<\/lastBuildDate>/g, "")
+    .replace(/<generator>[^<]*<\/generator>/g, "")
+    .replace(/></g, ">\n<")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+async function compareFeed(feedPath: string): Promise<PageResult> {
+  const [prodXml, previewXml] = await Promise.all(
+    [`${PROD_URL}${feedPath}`, `${PREVIEW_URL}${feedPath}`].map(async (url) => {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`${url} returned HTTP ${res.status}`);
+      return res.text();
+    }),
+  );
+  const prodLines = normalizeFeed(prodXml);
+  const previewLines = normalizeFeed(previewXml);
+  return {
+    path: feedPath,
+    pixelDiffRatio: 0,
+    markupChangedLines: countChangedLines(prodLines, previewLines),
+    markupTotalLines: Math.max(prodLines.length, previewLines.length),
+  };
 }
 
 async function screenshot(page: Page, url: string): Promise<Buffer> {
@@ -166,6 +201,22 @@ async function main(): Promise<void> {
 
   await browser.close();
 
+  for (const feedPath of FEEDS) {
+    try {
+      results.push(await compareFeed(feedPath));
+      console.log(`compared ${feedPath}`);
+    } catch (e) {
+      results.push({
+        path: feedPath,
+        pixelDiffRatio: Number.NaN,
+        markupChangedLines: 0,
+        markupTotalLines: 0,
+        error: (e as Error).message.slice(0, 200),
+      });
+      console.error(`failed ${feedPath}: ${(e as Error).message.slice(0, 200)}`);
+    }
+  }
+
   const lines = [
     `Comparing preview (${PREVIEW_URL}) against production (${PROD_URL}).`,
     "",
@@ -177,9 +228,9 @@ async function main(): Promise<void> {
       lines.push(`| \`${r.path}\` | — | — | ⚠️ ${r.error} |`);
       continue;
     }
-    const pct = (r.pixelDiffRatio * 100).toFixed(2);
+    const pct = FEEDS.includes(r.path) ? "—" : `${(r.pixelDiffRatio * 100).toFixed(2)}%`;
     const flag = r.pixelDiffRatio > FLAG_RATIO || r.markupChangedLines > 0 ? "👀" : "✅";
-    lines.push(`| \`${r.path}\` | ${pct}% | ${r.markupChangedLines} of ~${r.markupTotalLines} | ${flag} |`);
+    lines.push(`| \`${r.path}\` | ${pct} | ${r.markupChangedLines} of ~${r.markupTotalLines} | ${flag} |`);
   }
   lines.push(
     "",


### PR DESCRIPTION
Cleanup bucket 3 of 5: a testing pipeline that validates every PR's preview deployment against the live production site, so pipeline-touching changes (remark-gfm dedupe, image fixes — buckets 4 and 5) can be verified to be visual no-ops before merging.

## How it works

A new `visual-diff` job runs in the existing Cloudflare Pages workflow after the preview deployment finishes:

1. `scripts/visual-diff.ts` loads a representative set of pages — each layout (home, about, daily, tag) plus posts exercising the trickier pipeline features (Mermaid, Excalidraw, content images, code blocks) — on both the preview URL and `https://respawn.io`.
2. **Visual check:** full-page screenshots of both, diffed with `pixelmatch`. Pages diverging beyond 0.02% of pixels get prod/preview/diff PNGs saved.
3. **Markup check:** HTML from both is normalized (hashed `/_astro/` asset names, Astro scope ids, and the generator meta stripped) and compared line-wise, so a content-identical rebuild reports 0 changed lines.
4. **Feed check:** `/rss/feed.xml` is fetched from both, normalized (`lastBuildDate`/`generator` stripped, elements split to lines), and diffed the same way — guarding the RSS pipeline ahead of upcoming feed-rendering changes.
5. The per-page summary is posted as a PR comment (updated in place on subsequent pushes), and screenshots + diffs are uploaded as a workflow artifact.

The job is **informational — it never fails the build**. Index pages and the feed legitimately change when a PR adds content, so a human reads the report.

## Implementation notes

- Runs with `node --experimental-strip-types` — no TS runner dependency needed (`tsx` was removed in #37).
- New devDependencies: `pixelmatch`, `pngjs` (+ types). No SaaS, no new secrets, no baselines to maintain — production is the baseline.
- `CHROMIUM_PATH` env var lets local environments point at a system Chromium.
- Skips automatically for fork PRs (no preview deployment exists).

## Verification

- Rebased on `main` after #36/#37; the diff is purely additive again.
- Tested locally by serving `dist/` on two ports: identical copies report 0.00% pixel / 0 markup changes on all 8 pages; a modified page correctly flags and produces diff images; a perturbed feed correctly reports exactly the changed lines (`2 of ~2274`).
- First CI dogfood run reported 0.00% / 0 changes across all pages against live production.
- `pnpm run check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EB7Lr8nCrCwcg6fubx6uW