### PR TITLE
Remove redundant remark-gfm from astro config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,6 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import rehypeMermaid from "rehype-mermaid";
 import callouts from "remark-callouts";
-import remarkGfm from "remark-gfm";
 import wikilinks from "remark-wiki-link";
 import { config } from "./blog.config.ts";
 // Build integrations
@@ -30,8 +29,9 @@ const hrefTemplate = (permalink) => {
 };
 const pageResolver = (name) => [name];
 
+// remark-gfm is not listed here: Astro applies GFM by default
+// (markdown.gfm: true), so adding it would run the transform twice.
 const remarkPlugins = [
-  remarkGfm,
   remarkDek,
   remarkMark,
   [remarkFigureCaption, { captionClassName: "text-center italic mx-auto block" }],


### PR DESCRIPTION
Cleanup bucket 4 of 5.

Astro applies `remark-gfm` by default (`markdown.gfm: true` in `@astrojs/markdown-remark`), so listing it explicitly in `remarkPlugins` ran the GFM transform twice on every markdown file. This drops it from the config with a comment explaining why it's absent.

The `remark-gfm` package itself stays as a dependency — `src/pages/rss/feed.xml.ts` uses it in its standalone unified pipeline, which doesn't inherit Astro's markdown defaults.

## Verification

- Built the site with and without the explicit plugin: **byte-identical `dist/`** (full recursive diff; the feed compared equal modulo `lastBuildDate`).
- `pnpm run check` clean.
- The visual-diff job on this PR should report all ✅ against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EB7Lr8nCrCwcg6fubx6uW

---
_Generated by [Claude Code](https://claude.ai/code/session_019EB7Lr8nCrCwcg6fubx6uW)_