### PR TITLE
Fix homepage canonical URL to / instead of /index

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,9 +25,12 @@ interface Props {
 
 const { title = config.title, description = config.description, ogImage, ogType = "website" } = Astro.props;
 
-// Remove .html extension from pathname to match NextJS canonical URLs
-const pathnameWithoutHtml = Astro.url.pathname.replace(/\.html$/, "");
-const canonicalURL = new URL(pathnameWithoutHtml, Astro.site);
+// Normalize the pathname to the site's canonical URLs (build.format: "file").
+// Strip a trailing `.html`, then collapse a trailing `/index` to `/` so the
+// homepage canonicalizes to `https://respawn.io/` instead of `.../index`
+// (keeps canonical + og:url in agreement with the sitemap).
+const canonicalPathname = Astro.url.pathname.replace(/\.html$/, "").replace(/\/index$/, "/");
+const canonicalURL = new URL(canonicalPathname, Astro.site);
 ---
 
 <!doctype html>


### PR DESCRIPTION
## Problem

The built homepage (`dist/index.html`) advertised its canonical URL as `https://respawn.io/index`, while the sitemap correctly lists the homepage as `https://respawn.io`. That disagreement is exactly the "Alternate page with proper canonical tag" Search Console situation the sitemap `serialize()` workaround in `astro.config.mjs` was added to avoid — but the canonical side of it was never fixed. `og:url` had the same wrong value.

Root cause: under `build.format: "file"`, the homepage's `Astro.url.pathname` is `/index`, and `BaseLayout.astro` only stripped a trailing `.html` when computing the canonical — leaving the `/index`.

## Fix

In `src/layouts/BaseLayout.astro`, after stripping `.html`, also collapse a trailing `/index` to `/`, so the homepage canonicalizes to `https://respawn.io/`. `og:url` shares the same computed value and is fixed with it.

## Verification

`pnpm run build`, then:

- `dist/index.html` → `canonical` and `og:url` are both `https://respawn.io/` (was `.../index`).
- Other pages unchanged: `/about` → `https://respawn.io/about`, `/daily` → `https://respawn.io/daily`, `/posts/2026-redesign` → `https://respawn.io/posts/2026-redesign`.

The CI visual-diff job should show 2 markup lines changed on the homepage only (canonical + og:url), 0.00% pixel diff everywhere.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4rAWAv3FGWF7BdA6KCPnF)_