### PR TITLE
Drop trailing slashes from RSS item links and guids

### DIFF
--- a/src/pages/rss/feed.xml.ts
+++ b/src/pages/rss/feed.xml.ts
@@ -67,7 +67,7 @@ export async function GET(context: APIContext) {
         title: formattedTitle,
         description: rawExcerpt,
         content: content,
-        link: `/posts/${post.id}/`,
+        link: `/posts/${post.id}`,
         pubDate: post.data.created,
         author: config.author.email,
       };
@@ -79,6 +79,12 @@ export async function GET(context: APIContext) {
     description: config.description,
     site: context.site || config.baseURL,
     items: items,
+    // The site builds with `build.format: "file"`, so canonical URLs have no
+    // trailing slash. @astrojs/rss appends one by default, which makes every
+    // feed-reader click take an extra Cloudflare 308 redirect and makes guids
+    // disagree with the pages' canonical URLs — turn it off so item links/guids
+    // match the canonical form.
+    trailingSlash: false,
     customData: `<language>en-us</language>`,
   });
 }


### PR DESCRIPTION
## Problem

`src/pages/rss/feed.xml.ts` emitted item links and guids with a trailing slash:

```
https://respawn.io/posts/2026-redesign/
```

But the site builds with `build.format: "file"`, so the real canonical URL is `/posts/2026-redesign` (no trailing slash). Cloudflare Pages 308-redirects the slashed form, so links work — but every feed-reader click takes an extra redirect hop, and the guid (an item's identity in feed readers) doesn't match the canonical URL.

Dropping the trailing slash in the `link` string alone isn't enough: `@astrojs/rss` defaults `trailingSlash: true` and re-appends the slash when it builds the canonical URL for each item.

## Fix

Set `trailingSlash: false` on the `rss()` call so item links and guids match the un-slashed canonical URLs the site emits.

This is a deliberate one-time guid change: subscribers' readers will re-show existing posts as new **once**. Better to take that churn now, while the audience is small, than after it grows.

## Verification

`pnpm run build`, then `dist/rss/feed.xml`:

- `<link>`/`<guid>` values are now `https://respawn.io/posts/<slug>` (no trailing slash), matching the pages' canonical URLs.

CI visual-diff: only `/rss/feed.xml` flags; changed lines = 2 × number of posts (old + new link/guid lines).

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4rAWAv3FGWF7BdA6KCPnF)_