### PR TITLE
Bump GitHub Actions to current majors (fix Node 20 deprecation warnings)

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy to Cloudflare Pages
         id: deploy
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request' && steps.deploy.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const url = "${{ steps.deploy.outputs.deployment-url }}";
@@ -87,13 +87,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -110,13 +110,13 @@ jobs:
           PREVIEW_URL: ${{ needs.build-and-deploy.outputs.preview-url }}
 
       - name: Upload report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-diff-report
           path: visual-diff-report/
 
       - name: Comment diff summary on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
## Problem

Every run of `.github/workflows/cloudflare-pages.yml` logged runner deprecation warnings:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v4`.

## Fix

Bump every pinned action in both jobs (`build-and-deploy` and `visual-diff`) to its current major:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `pnpm/action-setup` | v4 | v6 |
| `actions/setup-node` | v4 | v7 |
| `actions/github-script` | v7 | v9 |
| `actions/upload-artifact` | v4 | v7 |
| `cloudflare/wrangler-action` | v3 | v4 |

Notes on breaking changes reviewed:

- **setup-node**: `cache: pnpm` is still valid and unchanged; the workflow already runs `pnpm/action-setup` *before* `setup-node`, so cache resolution keeps working.
- **wrangler-action v4**: the only notable change is that the bundled Wrangler CLI now defaults to v4. The `pages deploy dist/ --project-name=… --branch=…` command and the `apiToken`/`accountId` inputs are unchanged.

This changes CI configuration only — no site output changes.

## Verification

On this PR, confirm: build + preview deploy succeed, the preview-URL and visual-diff comments both post, the artifact uploads, and the Node 20 deprecation warnings are gone from the job log. The visual-diff report should be all ✅.

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4rAWAv3FGWF7BdA6KCPnF)_