### PR TITLE
Housekeeping: clear lint warning and check hints, tidy deps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -86,7 +86,10 @@ export default defineConfig({
     // Use Astro's built-in Shiki syntax highlighting
     syntaxHighlight: {
       type: "shiki",
-      excludeLangs: ["mermaid"],
+      // `mermaid` is rendered by rehype-mermaid; `pseudo-mermaid` is an
+      // intentional pseudo-code fence in a post — exclude both from Shiki so it
+      // doesn't warn "language doesn't exist, falling back to plaintext".
+      excludeLangs: ["mermaid", "pseudo-mermaid"],
     },
     shikiConfig: {
       themes: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "check": "astro check && biome check"
   },
   "dependencies": {
-    "@astrojs/check": "^0.9.9",
     "@astrojs/mdx": "^7.0.3",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",
@@ -32,6 +31,7 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.9",
     "@biomejs/biome": "^2.5.5",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ importers:
 
   .:
     dependencies:
-      '@astrojs/check':
-        specifier: ^0.9.9
-        version: 0.9.9(prettier@3.9.6)(typescript@6.0.3)
       '@astrojs/mdx':
         specifier: ^7.0.3
         version: 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.1)(jiti@2.7.0)(rollup@4.60.4)(tsx@4.23.1)(yaml@2.8.3))
@@ -76,6 +73,9 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
     devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.9
+        version: 0.9.9(prettier@3.9.6)(typescript@6.0.3)
       '@biomejs/biome':
         specifier: ^2.5.5
         version: 2.5.5

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,7 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
+// `z` re-exported from `astro:content` is deprecated; import it from astro/zod.
+import { z } from "astro/zod";
 
 const posts = defineCollection({
   loader: glob({

--- a/src/lib/rehypeExcalidraw.ts
+++ b/src/lib/rehypeExcalidraw.ts
@@ -35,7 +35,7 @@ const rehypeExcalidraw: Plugin<[ExcalidrawOptions?], Root> = (options = {}) => {
       const textNode = paragraph.children[0];
       if (textNode.type !== "text") continue;
       const match = textNode.value.trim().match(EXCALIDRAW_PATTERN);
-      if (!match || !match[1]) continue;
+      if (!match?.[1]) continue;
 
       const diagramName = match[1];
       const parentDir = dirname(file.path);


### PR DESCRIPTION
Grab-bag of small cleanups so `pnpm run check` comes back clean. Build output is unchanged.

## Changes

- [x] **Biome `useOptionalChain` warning** (`src/lib/rehypeExcalidraw.ts:38`): `!match || !match[1]` → `!match?.[1]`. This was the one persistent warning in `pnpm run check`.
- [x] **27 `astro check` hints**: all of them were `ts(6385) 'z' is deprecated` in `src/content.config.ts`. `z` re-exported from `astro:content` is deprecated, so import it from `astro/zod` instead. `astro check` now reports **0 errors / 0 warnings / 0 hints**.
- [x] **`pseudo-mermaid` code-fence** (`src/content/posts/contentlayer-mermaid-diagrams.md`): Shiki warned `The language "pseudo-mermaid" doesn't exist, falling back to "plaintext"` on every build. Added `pseudo-mermaid` to Shiki `excludeLangs` in `astro.config.mjs` (next to `mermaid`), preserving the author's intentional pseudo-code fence label while silencing the warning.
- [x] **`@astrojs/check` in `dependencies`**: moved to `devDependencies` (it's a check-time tool — no runtime effect on a static site). Lockfile updated.

## Out of scope

- **Stale GitHub repo description** — this is a repo-settings change requiring admin access, not a code change, so it can't be done in this PR. Left for a maintainer.
- **Biome `recommended` → `preset` config deprecation** — surfaces as an `info` (not a warning); `biome migrate` would rewrite `biome.json`. Left out to keep this PR focused; happy to do it separately.

## Verification

- `pnpm run check` → no `useOptionalChain` warning; `astro check` shows 0 warnings / 0 hints.
- `pnpm run build` → succeeds (87 pages), no `pseudo-mermaid` Shiki warning; site output unchanged (CI visual-diff all ✅).

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4rAWAv3FGWF7BdA6KCPnF)_