### PR TITLE
Strip MDX import/export from RSS content for .mdx posts

### DIFF
--- a/src/pages/rss/feed.xml.ts
+++ b/src/pages/rss/feed.xml.ts
@@ -35,6 +35,42 @@ function rehypeAbsoluteImages() {
   };
 }
 
+/**
+ * Strip MDX's ESM `import`/`export` statements from a post body.
+ *
+ * The RSS pipeline below is plain markdown (remark-parse), so it doesn't
+ * understand MDX. For `.mdx` posts whose body opens with `import x from "..."`,
+ * those lines would otherwise render as a paragraph of literal source in the
+ * feed (see #41). Astro's own MDX compiler drops them; this mirrors that.
+ *
+ * Lines inside fenced code blocks are left untouched, so tutorial posts that
+ * *show* import/export code in a fence keep it. JSX component tags (`<Aside>`,
+ * `<Script>`, …) don't need handling here — remark-rehype already drops raw
+ * HTML, so their tags vanish while the prose inside them survives.
+ *
+ * Only applied to `.mdx` bodies: a real `.md` post could legitimately open a
+ * prose line with the word "import"/"export", and those aren't ESM.
+ */
+function stripMdxEsm(body: string): string {
+  const fence = /^\s*(```+|~~~+)/;
+  const esm = /^\s*(import|export)\s/;
+  let openFence: string | null = null;
+  return body
+    .split("\n")
+    .filter((line) => {
+      const fenceMatch = line.match(fence);
+      if (fenceMatch) {
+        const marker = fenceMatch[1][0];
+        if (openFence === null) openFence = marker;
+        else if (line.trimStart().startsWith(openFence)) openFence = null;
+        return true;
+      }
+      // Drop top-level (non-fenced) ESM statement lines.
+      return openFence !== null || !esm.test(line);
+    })
+    .join("\n");
+}
+
 /** Convert post markdown body to simple HTML suitable for RSS readers. */
 async function bodyToHTML(body: string): Promise<string> {
   const result = await unified()
@@ -61,7 +97,8 @@ export async function GET(context: APIContext) {
     posts.map(async (post) => {
       const formattedTitle = titleCase(post.data.title);
       const rawExcerpt = getRawExcerpt(post.data.excerpt);
-      const content = post.body ? await bodyToHTML(post.body) : "";
+      const body = post.filePath?.endsWith(".mdx") && post.body ? stripMdxEsm(post.body) : post.body;
+      const content = body ? await bodyToHTML(body) : "";
 
       return {
         title: formattedTitle,


### PR DESCRIPTION
## Problem

`src/pages/rss/feed.xml.ts` builds `<content:encoded>` by running `bodyToHTML()` — a plain unified markdown pipeline (remark-parse → remark-gfm → remark-rehype → rehype-stringify) — over `post.body`. For `.md` posts this is fine, but for `.mdx` posts the body is raw MDX, so ESM `import`/`export` statements at the top of the file rendered as a paragraph of literal source in the feed.

Concretely, the `2026-redesign` entry began with:

```
import beforeHome from "./_assets/2026-redesign/before-home.png";
import afterHome from "./_assets/2026-redesign/after-home.png";
…
```

## Scope of the actual leak

I scanned every item's `<content:encoded>` (with `<pre>`/`<code>` blocks removed, to ignore legitimately-displayed code). The **only** flow-text MDX leak in the whole feed was that one post's top-of-file `import` block. Two other MDX constructs need no handling:

- **JSX component tags** (`<WithAside>`, `<Aside>`, `<Script>`) — `remark-rehype` already drops raw HTML, so the tags vanish while the prose inside them survives.
- **`<style>{…}</style>` blocks** — dropped as raw HTML too.

## Fix (issue's option 2, kept simple)

Add a small **fence-aware** `stripMdxEsm()` that removes top-level `import`/`export` statement lines before the markdown pipeline, applied only to `.mdx` bodies (via `post.filePath`). Lines inside fenced code blocks are preserved, so tutorial posts that *show* import/export code keep it. Gating on `.mdx` avoids touching a real `.md` post that might open a prose line with the word "import".

This adds no dependency (a full MDX parse via `remark-mdx` would be heavier and can't safely run over `.md` bodies, which aren't valid MDX).

## Verification

`pnpm run build`, then scanning `dist/rss/feed.xml`:

- No `import`/`export` flow-text leaks remain; `2026-redesign` now begins with its actual prose (`<article><p>I remember a year ago…`).
- Tutorial posts (`contentlayer-with-excalidraw`, `contentlayer-with-multiple-data-types`) keep their `import` code examples inside `<pre>`.
- `astro check` → 0 errors / 0 warnings.

CI visual-diff: only `/rss/feed.xml` should flag (the `2026-redesign` content lines).

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4rAWAv3FGWF7BdA6KCPnF)_